### PR TITLE
Add DI/EI in some SUBs. Improve code in callVtAddress. Comments to remind logics of these SUBs.

### DIFF
--- a/src/128/vortexTracker.bas
+++ b/src/128/vortexTracker.bas
@@ -1,6 +1,12 @@
 DIM VortexTracker_Status AS UByte = 0
+
+' This SUB used PaginarMemoria previously, which included/d DI/EI.
+' Without PaginarMemoria, DI/EI *must* be done explicitly.
 'usarIM2 (byte): 1 utiliza el motor de interrupciones
 SUB VortexTracker_Inicializar(usarIM2 AS UByte)
+  ASM
+    di
+  END ASM
   if inMenu
     callVtAddress($C000)
   else
@@ -13,6 +19,9 @@ SUB VortexTracker_Inicializar(usarIM2 AS UByte)
       ' interrupción
       IM2_Inicializar(@VortexTracker_NextNote)
   END IF
+  ASM
+    ei
+  END ASM
   ' Estado: 1 (sonando)
   VortexTracker_Status = 1
 END SUB
@@ -30,31 +39,43 @@ SUB FASTCALL VortexTracker_NextNote()
   end if
 END SUB
 
+' This SUB used PaginarMemoria previously, which included DI/EI.
+' Without PaginarMemoria, DI/EI *must* be done explicitly.
 SUB VortexTracker_Stop()
   VortexTracker_Status = 0
 
+  ASM
+    di
+  END ASM
   if inMenu
     callVtAddress($C008)
   else
     callVtAddress(VTPLAYER_MUTE)
   end if
+  ASM
+    ei
+  END ASM
 END SUB
 
+' This SUB *must* be used with dissabled INTs:
+' either inside an ISR (VortexTracker_NextNote),
+' or between DI/EI (VortexTracker_Inicializar and VortexTracker_Stop)
 sub fastcall callVtAddress(address as uinteger)
   ASM
     ld a,($5b5c)
     push af
     AND %11111000
-    OR          MUSIC_BANK; Memory Bank
+    OR  MUSIC_BANK; Memory Bank
     ld bc,$7ffd
+    push bc
     OUT (c),a
     push ix ; Guardamos ix
     ld (callhl+1),hl
 callhl:
     call $1234; Saltar a la dirección en HL
     pop ix ; Recuperamos ix
+    pop bc
     pop af
-    ld bc,$7ffd
     OUT (c),a
   END ASM
 end sub


### PR DESCRIPTION
Some SUBs used EI/DI implicitly, now they must use them explicitly.

Also, less error-prone, and more neat and short code (2 bytes) by PUSH/POP BC instead of a second LD BC,$7ffd (3 bytes).

Comments added to remind the logics of these SUBs.